### PR TITLE
Expose Instrument class for typing and improve README/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,43 @@
 # Guitar Chord Library
 
-A perfect simple chord library for guitar and ukulele. Both flat and sharp note usage are supported.
+A perfect, simple chord library for guitar and ukulele. Both flat and sharp note usage are supported.
 **Pull request are always welcome :)**
 
 ## Features
 
-Support Instruments
+Supported instruments:
 
 - Guitar
 - Ukulele
 
 ```dart
-/// default is guitar
+/// Default is guitar
 GuitarChordLibrary.instrument(InstrumentType.ukulele)
 ```
 
 ## Usage
 
-To use this plugin, add guitar_chord_library as a dependency in your [pubspec.yaml](https://flutter.io/using-packages/) file.
+To use this plugin, add ``guitar_chord_library`` as a dependency in your [pubspec.yaml](https://flutter.io/using-packages/) file.
 
 ```dart
 void main() {
-  /// your favour instrument
+  /// Your favourite instrument:
   /// InstrumentType.guitar
   /// InstrumentType.ukulele
-  var instrument = GuitarChordLibrary.instrument(InstrumentType.guitar);
+  Instrument instrument = GuitarChordLibrary.instrument(InstrumentType.guitar);
 
-  /// instrument string count
+  /// Instrument string count
   print(instrument.stringCount);
 
-  /// all marjor keys
+  /// All major keys
   print(instrument.getKeys()); //use sharp
   print(instrument.getKeys(true)); //use flat
 
-  /// all chords by major key
+  /// All chords by major key
   print(instrument.getChordsByKey('C#')); //use sharp
   print(instrument.getChordsByKey('C#', true)); //use flat
 
-  /// all positions of Cmajor chord
+  /// All positions of Cmajor chord
   final chordPostions = instrument.getChordPositions('C', 'major')!;
 
   for (var position in chordPostions) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,7 @@ void main() {
   /// your favour instrument
   /// InstrumentType.guitar
   /// InstrumentType.ukulele
-  var instrument = GuitarChordLibrary.instrument(InstrumentType.guitar);
+  Instrument instrument = GuitarChordLibrary.instrument(InstrumentType.guitar);
 
   /// instrument string count
   print(instrument.stringCount);

--- a/lib/guitar_chord_library.dart
+++ b/lib/guitar_chord_library.dart
@@ -3,3 +3,4 @@ library guitar_chord_library;
 export './src/chord.dart';
 export './src/chord_helper.dart';
 export './src/chord_library.dart';
+export './src/instrument/instrument.dart';

--- a/lib/src/instrument/guitar.dart
+++ b/lib/src/instrument/guitar.dart
@@ -1,6 +1,5 @@
 import '../../guitar_chord_library.dart';
 import '../dataset/guitar_dataset.dart';
-import 'instrument.dart';
 
 /// Instrument implentation as Guitar
 class Guitar extends Instrument {


### PR DESCRIPTION
Currently, you need to reach into the package in order to get the class to type ``Instrument``.

This PR exposes the ``Instrument`` class to the public facing import. It also improves the README (fixes typos) and updates the examples to reflect the changes of this PR.